### PR TITLE
Fix bosh flow

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -324,7 +324,7 @@ Client.prototype.connect = function (opts, transInfo) {
         if (transInfo.name === 'bosh') {
             this.use(require('./plugins/bosh'));
         }
-        var trans = self.transport = new self.transports[transInfo.name](self.sm, self.stanzas);
+        var trans = self.transport = new self.transports[transInfo.name](self.sm, self.stanzas, self);
         trans.on('*', function (event, data) {
             self.emit(event, data);
         });

--- a/lib/transports/bosh.js
+++ b/lib/transports/bosh.js
@@ -67,7 +67,7 @@ function retryRequest(opts, timeout, allowedRetries) {
 }
 
 
-function BOSHConnection(sm, stanzas) {
+function BOSHConnection(sm, stanzas, client) {
     var self = this;
 
     WildEmitter.call(this);
@@ -83,11 +83,7 @@ function BOSHConnection(sm, stanzas) {
     self.requests = [];
     self.maxRequests = undefined;
     self.sid = '';
-    self.authenticated = false;
-
-    self.on('auth:success', function() {
-        self.authenticated = true;
-    });
+    self.client = client;
 
     self.on('raw:incoming', function (data) {
         data = data.trim();
@@ -147,7 +143,7 @@ BOSHConnection.prototype.connect = function (opts) {
 
     self.config = extend({
         rid: Math.ceil(Math.random() * 9999999999),
-        wait: 30,
+        wait: 60,
         maxRetries: 5
     }, opts);
 
@@ -219,11 +215,13 @@ BOSHConnection.prototype.longPoll = function () {
     if (!this.sid || (!canReceive && !canSend)) {
         return;
     }
-
     var stanzas = this.sendQueue;
     this.sendQueue = [];
-    this.rid++;
 
+    if (stanzas.length === 0 && (!this.client.sessionStarted)) {
+        return;
+    }
+    this.rid++;
     this.request(new this.stanzas.BOSH({
         payload: stanzas
     }));
@@ -266,8 +264,7 @@ BOSHConnection.prototype.request = function (bosh) {
         self.requests = filter(self.requests, function (item) {
             return item.id !== ticket.id;
         });
-        // do not (re)start long polling if terminating, or request is pending, or before authentication
-        if (bosh.type !== 'terminate' && !self.requests.length && self.authenticated) {
+        if (bosh.type !== 'terminate' && !self.requests.length) {
             // Delay next auto-request by two ticks since we're likely
             // to send data anyway next tick.
             process.nextTick(function () {

--- a/lib/transports/bosh.js
+++ b/lib/transports/bosh.js
@@ -83,6 +83,11 @@ function BOSHConnection(sm, stanzas) {
     self.requests = [];
     self.maxRequests = undefined;
     self.sid = '';
+    self.authenticated = false;
+
+    self.on('auth:success', function() {
+        self.authenticated = true;
+    });
 
     self.on('raw:incoming', function (data) {
         data = data.trim();
@@ -261,7 +266,8 @@ BOSHConnection.prototype.request = function (bosh) {
         self.requests = filter(self.requests, function (item) {
             return item.id !== ticket.id;
         });
-        if (bosh.type !== 'terminate' && !self.requests.length) {
+        // do not (re)start long polling if terminating, or request is pending, or before authentication
+        if (bosh.type !== 'terminate' && !self.requests.length && self.authenticated) {
             // Delay next auto-request by two ticks since we're likely
             // to send data anyway next tick.
             process.nextTick(function () {


### PR DESCRIPTION
## UGLY FIX TO RESPECT XEP_0206 flow

> Upon receiving the <success/> element, the client MUST then ask the connection manager to restart the stream by sending a "restart request"

A good fix would be to rewrite bosh implementation, to be able to prevent empty stanza from being sent while not authenticated.

Until bosh support is dropped, I'll have to live with that, waking up at night, because of that shitty hack.